### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For instance if you have an element with id `#my-slider` and you want to change:
 - arrows color
 
 	```css
-#my-slider .arrows label {
+# my-slider .arrows label {
 		border-left-color: red;
 		border-right-color: red;
 }
@@ -90,7 +90,7 @@ For instance if you have an element with id `#my-slider` and you want to change:
 - inside navigation border
 
 	```css
-#my-slider.inside .navigation label {
+# my-slider.inside .navigation label {
 		border: 1px solid red;
 }
 	```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
